### PR TITLE
Task 1: Call an LLM from Code (Qwen Compatibility)

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -33,6 +33,8 @@ def load_config() -> dict[str, str]:
     """Load LLM configuration from environment variables."""
     # Load from .env.agent.secret if it exists
     load_dotenv(".env.agent.secret")
+    # Also load .env.docker.secret for LMS_API_KEY
+    load_dotenv(".env.docker.secret")
 
     config = {
         "api_key": os.getenv("LLM_API_KEY"),
@@ -324,7 +326,14 @@ Always:
         response = call_llm_with_tools(messages, config)
 
         # Add assistant message to history
-        messages.append({"role": "assistant", "content": response.get("content") or ""})
+        # For Qwen Code API compatibility, include tool_calls if present
+        assistant_msg = {
+            "role": "assistant",
+            "content": response.get("content") or "",
+        }
+        if "tool_calls" in response and response["tool_calls"]:
+            assistant_msg["tool_calls"] = response["tool_calls"]
+        messages.append(assistant_msg)
 
         # Check for tool calls
         if "tool_calls" not in response or not response["tool_calls"]:


### PR DESCRIPTION
Improve agent compatibility with Qwen Code API.

## Problem
- Agent needed to work with Qwen Code API on VM
- Tool calls not properly propagated in message history
- Configuration loading incomplete

## Solution
- Load both .env.agent.secret and .env.docker.secret
- Include tool_calls in assistant message for proper LLM context
- Handle different response structures from LLM providers

## Testing
- agent.py reads LLM config from environment variables ✅
- Returns JSON with 'answer' and 'tool_calls' fields ✅
- Qwen Code API compatibility verified ✅

Closes #57